### PR TITLE
Change middle tab calculation to use one-third index

### DIFF
--- a/src/modules/ytmusic/forceTab.js
+++ b/src/modules/ytmusic/forceTab.js
@@ -119,7 +119,7 @@
     const tabs = Array.from(container.querySelectorAll(SELECTORS.TAB));
     if (tabs.length < 3) return;
 
-    const middleIndex = Math.floor(tabs.length / 2);
+    const middleIndex = Math.floor(tabs.length / 3);
     const middleTab = tabs[middleIndex];
 
     forceActivateMiddleTab(middleTab);


### PR DESCRIPTION
YT Music recently added a new 'Comments' tab which makes the extension put the lyrics in there instead.
<img width="1323" height="1678" alt="image" src="https://github.com/user-attachments/assets/f06d9a87-9d14-4c78-bbe8-6d8e7b8ee603" />
