### PR TITLE
fix: miniplayer fullscreen bug

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "YouLy+",
   "default_locale": "en",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "__MSG_extensionDescription__",
   "permissions": [
     "storage"

--- a/src/modules/ytmusic/style.css
+++ b/src/modules/ytmusic/style.css
@@ -14,18 +14,8 @@ ytmusic-app-layout[player-fullscreened] .song-media-controls.ytmusic-player {
     background: none;
 }
 
-/* ==========================================================================
-   FULLSCREEN BLANK SCREEN FIX
-   YouTube Music animates the player-page into view using
-   transform: translateY(100vh) → translateY(0). When transitioning directly
-   from MINIPLAYER → FULLSCREEN, this animation gets stuck at the start
-   position, leaving the player-page pushed one viewport height below the
-   screen (completely invisible). Override the stuck transform.
-   ========================================================================== */
-
-/* THE FIX: Force the player page to translateY(0) in fullscreen */
-ytmusic-app-layout[player-fullscreened] > [slot="player-page"],
-ytmusic-app-layout[player-ui-state="FULLSCREEN"] > [slot="player-page"] {
+ytmusic-app-layout[player-fullscreened]>[slot="player-page"],
+ytmusic-app-layout[player-ui-state="FULLSCREEN"]>[slot="player-page"] {
     transform: translateY(0) !important;
     visibility: visible !important;
     display: block !important;
@@ -468,7 +458,7 @@ div#lyrics-song-progressbar {
         --lyplus-font-size-base: calc(1.84vh + 1.84vw);
     }
 
-    ytmusic-app-layout:not([is-mweb-modernization-enabled])[player-fullscreened]>[slot="player-page"] #lyrics-plus-container .lyrics-plus-metadata{
+    ytmusic-app-layout:not([is-mweb-modernization-enabled])[player-fullscreened]>[slot="player-page"] #lyrics-plus-container .lyrics-plus-metadata {
         font-size: 0.8em;
     }
 

--- a/src/modules/ytmusic/style.css
+++ b/src/modules/ytmusic/style.css
@@ -14,6 +14,36 @@ ytmusic-app-layout[player-fullscreened] .song-media-controls.ytmusic-player {
     background: none;
 }
 
+/* ==========================================================================
+   FULLSCREEN BLANK SCREEN FIX
+   YouTube Music animates the player-page into view using
+   transform: translateY(100vh) → translateY(0). When transitioning directly
+   from MINIPLAYER → FULLSCREEN, this animation gets stuck at the start
+   position, leaving the player-page pushed one viewport height below the
+   screen (completely invisible). Override the stuck transform.
+   ========================================================================== */
+
+/* THE FIX: Force the player page to translateY(0) in fullscreen */
+ytmusic-app-layout[player-fullscreened] > [slot="player-page"],
+ytmusic-app-layout[player-ui-state="FULLSCREEN"] > [slot="player-page"] {
+    transform: translateY(0) !important;
+    visibility: visible !important;
+    display: block !important;
+}
+
+/* Ensure side-panel is visible in fullscreen */
+ytmusic-app-layout[player-fullscreened] #side-panel,
+ytmusic-app-layout[player-ui-state="FULLSCREEN"] #side-panel {
+    visibility: visible !important;
+}
+
+/* Ensure lyrics containers are visible */
+ytmusic-app-layout[player-fullscreened] #lyrics-plus-container,
+ytmusic-app-layout[player-ui-state="FULLSCREEN"] #lyrics-plus-container {
+    display: block !important;
+    visibility: visible !important;
+}
+
 /* Use song-art palette for lyrics in word-by-word mode */
 ytmusic-player-page[video-mode]:not([is-video-truncation-fix-enabled])[player-fullscreened] #lyrics-plus-container.use-song-palette-fullscreen.word-by-word-mode,
 #lyrics-plus-container.use-song-palette-all-modes.word-by-word-mode {


### PR DESCRIPTION
Bug Fix: YouTube Music Fullscreen Blank Screen
Problem: Jumping directly from MINIPLAYER → FULLSCREEN causes a blank screen because YouTube Music's CSS slide-up animation gets stuck, leaving the player page rendered entirely off-screen (transform: translateY(993px)).

Solution:

CSS (style.css): Added a rule to override the stuck animation by forcing (transform: translateY(0) !important) when the layout attributes detect fullscreen state.

JS (forceTab.js): Refactored to monitor UI transitions, handle the layout's new single-renderer tab structure, force the lyrics tab to select, and trigger content re rendering.